### PR TITLE
New method of determining bot we're running on based on mapping of MA…

### DIFF
--- a/src/main/java/frc/robot/subsystem/SubsystemFactory.java
+++ b/src/main/java/frc/robot/subsystem/SubsystemFactory.java
@@ -1,7 +1,11 @@
 package frc.robot.subsystem;
 
 import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.logging.Logger;
 
 import frc.robot.OI;
@@ -32,9 +36,8 @@ public class SubsystemFactory {
 
     static Logger logger = Logger.getLogger(SubsystemFactory.class.getName());
 
-    private static String botMacAddress;
-
-    private String footballMacAddress = "00:80:2F:17:D7:4B";
+    private static String botName; 
+    private HashMap<String,String> allMACs; // will contain mapping of MACs to Bot Names
 
     private static DisplayManager displayManager;
 
@@ -52,6 +55,14 @@ public class SubsystemFactory {
 
     private SubsystemFactory() {
         // private constructor to enforce Singleton pattern
+        botName = "unknown";
+        allMACs = new HashMap<>();  
+        // add all the mappings from MACs to names here
+        // as you add mappings here:
+        //    1) update the select statement in the init method 
+        //    2) add the init method for that robot
+        allMACs.put("00:80:2F:17:BD:76","zombie"); //usb0
+        allMACs.put("00:80:2F:17:BD:75","zombie"); //eth0
     }
 
     public static SubsystemFactory getInstance(boolean b) {
@@ -67,20 +78,31 @@ public class SubsystemFactory {
 
         logger.info("initializing");
 
-        botMacAddress = InetAddress.getLocalHost().getHostAddress().trim();
-        botMacAddress = footballMacAddress;
+        Enumeration<NetworkInterface> networks = NetworkInterface.getNetworkInterfaces();
+        String activeMACs = "";
+        for (NetworkInterface net : Collections.list(networks)) {
+            String mac = formatMACAddress(net.getHardwareAddress());
+            activeMACs += (mac+" ");
+            logger.info("Network #"+net.getIndex()+" "+net.getName()+" "+mac);
+            if (allMACs.containsKey(mac)) {
+                botName = allMACs.get(mac);
+                logger.info("   this MAC is for "+botName);
+            }
+        }
 
-        logger.info("[" + botMacAddress + "]");
+        logger.info("Running on "+botName);
 
         displayManager = dm;
         subsystemInterfaceList = new ArrayList<SBInterface>();
 
         try {
 
-            if (botMacAddress.equals(footballMacAddress) || botMacAddress == null || botMacAddress.equals("")) {
-                initFootball(portMan);
-            } else {
-                throw new Exception("Unrecognized MAC Address [" + botMacAddress + "]");
+            // Note that you should update this switch statement as you add bots to the list above
+            switch (botName) {
+                case "football": initFootball(portMan); break;
+                case "unknown": initFootball(portMan); break;  // default to football if we don't know better
+                case "zombie": initZombie(portMan); break;
+                default: throw new Exception("Unrecognized MAC Address [" + activeMACs + "]");
             }
 
             initCommon(portMan);
@@ -172,6 +194,10 @@ public class SubsystemFactory {
         OI.getInstance().bind(st2, OI.LeftJoyButton5, OI.WhenPressed);
     }
 
+    private void initZombie(PortMan portMan) throws OzoneException {
+        logger.info("Initializing Zombie");
+    }
+
     public ControlPanel getControlPanel() {
         return controlPanel;
     }
@@ -187,4 +213,28 @@ public class SubsystemFactory {
     public static ArrayList<SBInterface> getSBInterfaceList() {
         return subsystemInterfaceList;
     }
+
+    /**
+     * Formats the byte array representing the mac address as more human-readable form
+     * @param hardwareAddress byte array
+     * @return string of hex bytes separated by colons
+     */
+    private String formatMACAddress(byte[] hardwareAddress) {
+        if (hardwareAddress == null || hardwareAddress.length == 0) {
+            return "";
+        }
+        StringBuilder mac = new StringBuilder(); // StringBuilder is a premature optimization here, but done as best practice
+        for (int k=0;k<hardwareAddress.length;k++) {
+            int i = hardwareAddress[k] & 0xFF;  // unsigned integer from byte
+            String hex = Integer.toString(i,16);
+            if (hex.length() == 1) {  // we want to make all bytes two hex digits 
+                hex = "0"+hex;
+            }
+            mac.append(hex.toUpperCase());
+            mac.append(":");
+        }
+        mac.setLength(mac.length()-1);  // trim off the trailing colon
+        return mac.toString();
+    }
+
 }


### PR DESCRIPTION
@worthp Take a look at this and see what you think.

In testing, it appears that (as one would expect) that the USB and Ethernet ports have different MAC addresses. We can iterate through the active networks, but the inactive ones don't appear in the list of network interfaces. 

So depending on how you're connected to the both (USB vs. ethernet/radio) you will see a different MAC address. On the "dead" (zombie!?) RIO those MAC addresses are off by one, but I don't know that we can trust this to always be the case.

This change provides a mapping from multiple MAC addresses to a bot name, which we can then use to select which initialization to go through. The last matching MAC address will be used, which is probably fine because probably (I hope!) even the USB MAC addresses should be unique. If that turns out to not be the case this won't work, or at least won't work consistently. 

Test run with both USB and Ethernet connected:
********** Robot program starting ********** ﻿
﻿﻿﻿﻿﻿﻿ NT: server: client CONNECTED: 172.22.11.1 port 57784 ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.770][SubsystemFactory][initializing] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.908][SubsystemFactory][Network #3 usb0 00:80:2F:17:BD:76] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.914][SubsystemFactory][   this MAC is for zombie] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.918][SubsystemFactory][Network #2 eth0 00:80:2F:17:BD:75] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.921][SubsystemFactory][   this MAC is for zombie] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.925][SubsystemFactory][Network #1 lo ] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.930][SubsystemFactory][Running on zombie] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.935][SubsystemFactory][Initializing Zombie] ﻿

Test with just USB connected (after rebooting--the adapters will hang around after they've connected once, but disappear after a reboot!)
********** Robot program starting ********** ﻿
﻿﻿﻿﻿﻿﻿ NT: server: client CONNECTED: 172.22.11.1 port 58168 ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:00.944][SubsystemFactory][initializing] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:01.111][SubsystemFactory][Network #3 usb0 00:80:2F:17:BD:76] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:01.117][SubsystemFactory][   this MAC is for zombie] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:01.121][SubsystemFactory][Network #1 lo ] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:01.127][SubsystemFactory][Running on zombie] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:01.130][SubsystemFactory][Initializing Zombie] ﻿

Test with just ethernet connected:
 ********** Robot program starting ********** ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:01.722][SubsystemFactory][initializing] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:02.010][SubsystemFactory][Network #2 eth0 00:80:2F:17:BD:75] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:02.029][SubsystemFactory][   this MAC is for zombie] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:02.036][SubsystemFactory][Network #1 lo ] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:02.046][SubsystemFactory][Running on zombie] ﻿
﻿﻿﻿﻿﻿﻿ [INFO][00:02.052][SubsystemFactory][Initializing Zombie] ﻿

Note that in testing various combinations I did have situations where USB or ethernet appeared when I didn't expect it. Perhaps this is because I never powered down the RIO, but only did warm reboots. Also, it did seem that restarting robot code left the adapters visible, which makes sense since restarting robot code does not reboot the OS. 